### PR TITLE
Fix: Send admin password via X-Admin-Password header

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -104,8 +104,7 @@ then
         formattedmessages=$formattedmessages'|'$i
       done
 
-      json='{"authenticationPassword":"'$EMAILAUTHPASS'", "messages" : "'$formattedmessages'", "packageManaged": "false", "instructions": "https://github.com/voiceittech/VoiceIt2-Perl/releases/download/'$wrapperplatformversion'/voiceIt2.pm"}'
-      curl -X POST -H "Content-Type: application/json" -d $json "https://api.voiceit.io/platform/38"
+      curl -X POST -H "X-Admin-Password: $EMAILAUTHPASS" --data-urlencode "messages=$formattedmessages" -d "packageManaged=false" --data-urlencode "instructions=https://github.com/voiceittech/VoiceIt2-Perl/releases/download/$wrapperplatformversion/voiceIt2.pm" "https://api.voiceit.io/platform/38"
     fi
 
     exit 0


### PR DESCRIPTION
## Summary
- Moves `authenticationPassword` from JSON body to `X-Admin-Password` HTTP header
- Switches from JSON body to form-encoded params to match API 3 server's `@RequestParam` bindings

## Why
The API 3 server (Spring Boot) expects the admin password as an HTTP header, not a JSON body field. The previous approach would fail to authenticate against the new API.

Generated with [Claude Code](https://claude.com/claude-code)