### PR TITLE
Update internal references from VoiceIt2 to VoiceIt3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="./perl.png" width="100%" style="width:100%" />
 
-# VoiceIt2-Perl [![travis](https://app.travis-ci.com/voiceittech/VoiceIt2-Perl.svg?branch=master)](https://app.travis-ci.com/github/voiceittech/VoiceIt2-Perl) [![version](https://img.shields.io/github/v/release/voiceittech/VoiceIt2-Perl)](https://github.com/voiceittech/VoiceIt2-Perl/releases) ![MIT](https://img.shields.io/github/license/mashape/apistatus.svg)
+# VoiceIt3-Perl [![travis](https://app.travis-ci.com/voiceittech/VoiceIt3-Perl.svg?branch=master)](https://app.travis-ci.com/github/voiceittech/VoiceIt3-Perl) [![version](https://img.shields.io/github/v/release/voiceittech/VoiceIt3-Perl)](https://github.com/voiceittech/VoiceIt3-Perl/releases) ![MIT](https://img.shields.io/github/license/mashape/apistatus.svg)
 
 A Perl wrapper for VoiceIt's API 2.0 featuring Voice + Face Verification and Identification.
 
@@ -17,5 +17,5 @@ Contact us with any questions at support@voiceit.io
 
 ## License
 
-VoiceIt2-Perl is available under the MIT license. See the LICENSE file for more info.
+VoiceIt3-Perl is available under the MIT license. See the LICENSE file for more info.
 

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 commit=$(git log -1 --pretty=%B | head -n 1)
-version=$(echo $(curl -H "Authorization: token $GH_TOKEN" -s https://api.github.com/repos/voiceittech/VoiceIt2-Perl/releases/latest | grep '"tag_name":' |sed -E ' s/.*"([^"]+)".*/\1/') | tr "." "\n")
+version=$(echo $(curl -H "Authorization: token $GH_TOKEN" -s https://api.github.com/repos/voiceittech/VoiceIt3-Perl/releases/latest | grep '"tag_name":' |sed -E ' s/.*"([^"]+)".*/\1/') | tr "." "\n")
 set -- $version
 major=$1
 minor=$2
@@ -72,7 +72,7 @@ then
 
   if [[ $wrapperplatformversion = $version ]];
   then
-    uploadurl=$(curl -s -H "Authorization: token $GH_TOKEN" -H "Content-Type: application/json" --request POST --data '{"tag_name": "'$version'", "target_commitish": "master", "name": "'$version'", "body": "", "draft": false, "prerelease": false}' https://api.github.com/repos/voiceittech/VoiceIt2-Perl/releases | grep upload_url | awk '{print $2}' | cut -d '"' -f2 | cut -f1 -d '{')
+    uploadurl=$(curl -s -H "Authorization: token $GH_TOKEN" -H "Content-Type: application/json" --request POST --data '{"tag_name": "'$version'", "target_commitish": "master", "name": "'$version'", "body": "", "draft": false, "prerelease": false}' https://api.github.com/repos/voiceittech/VoiceIt3-Perl/releases | grep upload_url | awk '{print $2}' | cut -d '"' -f2 | cut -f1 -d '{')
     curl -H "Authorization: token $GH_TOKEN" -H "Content-Type: text/plain" -X POST --data-binary '@./voiceIt2.pm' $uploadurl'?name=voiceIt2.pm' 1>&2
 
     if [ "$?" != "0" ]
@@ -104,7 +104,7 @@ then
         formattedmessages=$formattedmessages'|'$i
       done
 
-      json='{"authenticationPassword":"'$EMAILAUTHPASS'", "messages" : "'$formattedmessages'", "packageManaged": "false", "instructions": "https://github.com/voiceittech/VoiceIt2-Perl/releases/download/'$wrapperplatformversion'/voiceIt2.pm"}'
+      json='{"authenticationPassword":"'$EMAILAUTHPASS'", "messages" : "'$formattedmessages'", "packageManaged": "false", "instructions": "https://github.com/voiceittech/VoiceIt3-Perl/releases/download/'$wrapperplatformversion'/voiceIt2.pm"}'
       curl -X POST -H "Content-Type: application/json" -d $json "https://api.voiceit.io/platform/38"
     fi
 


### PR DESCRIPTION
## Summary
- Repo has been renamed from VoiceIt2-* to VoiceIt3-*.
- Updated all internal references (URLs, package names, paths) to use VoiceIt3- instead of VoiceIt2-.

## Test plan
- [ ] Verify builds/tests pass with updated references
- [ ] Confirm all links point to correct VoiceIt3-* repositories

🤖 Generated with [Claude Code](https://claude.com/claude-code)