### PR TITLE
Remove switchSubAccountType (dead endpoint)

### DIFF
--- a/test.pl
+++ b/test.pl
@@ -101,10 +101,6 @@ assertEqual(201, $json->{status}, __LINE__);
 assertEqual('SUCC', $json->{responseCode}, __LINE__);
 my $unmanagedSubAccountAPI = $json->{apiKey};
 
-my $json = parse_json($myVoiceIt->switchSubAccountType($unmanagedSubAccountAPI));
-assertEqual(200, $json->{status}, __LINE__);
-assertEqual('SUCC', $json->{responseCode}, __LINE__);
-
 my $json = parse_json($myVoiceIt->regenerateSubAccountAPIToken($managedSubAccountAPI));
 assertEqual(200, $json->{status}, __LINE__);
 assertEqual('SUCC', $json->{responseCode}, __LINE__);

--- a/voiceIt2.pm
+++ b/voiceIt2.pm
@@ -639,17 +639,6 @@ sub createGroup(){
     return $reply->content();
   }
 
-  sub switchSubAccountType() {
-    shift;
-    my ($subAccountAPIKey) = @_;
-    my $ua = LWP::UserAgent->new();
-    my $request = POST $baseUrl.'/subaccount/'.$subAccountAPIKey.'/switchType'.$self->{notificationUrl};
-    $request->header('platformId' => $platformId);
-    $request->header('platformVersion' => $platformVersion);
-    $request->authorization_basic($apiKey, $apiToken);
-    my $reply = $ua->request($request);
-    return $reply->content();
-  }
 
   sub regenerateSubAccountAPIToken() {
     shift;


### PR DESCRIPTION
## Summary
- Removes `switchSubAccountType()` method from `voiceIt2.pm` — calls non-existent `/subaccount/{key}/switchType` endpoint
- Removes corresponding test assertions

## Test plan
- [ ] Verify no remaining references to `switchType` in codebase
- [ ] Run existing sub-account tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)