### PR TITLE
Rebrand VoiceIt2 to VoiceIt3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="./perl.png" width="100%" style="width:100%" />
 
-# VoiceIt2-Perl [![travis](https://app.travis-ci.com/voiceittech/VoiceIt3-Perl.svg?branch=master)](https://app.travis-ci.com/github/voiceittech/VoiceIt3-Perl) [![version](https://img.shields.io/github/v/release/voiceittech/VoiceIt3-Perl)](https://github.com/voiceittech/VoiceIt3-Perl/releases) ![MIT](https://img.shields.io/github/license/mashape/apistatus.svg)
+# VoiceIt3-Perl [![travis](https://app.travis-ci.com/voiceittech/VoiceIt3-Perl.svg?branch=master)](https://app.travis-ci.com/github/voiceittech/VoiceIt3-Perl) [![version](https://img.shields.io/github/v/release/voiceittech/VoiceIt3-Perl)](https://github.com/voiceittech/VoiceIt3-Perl/releases) ![MIT](https://img.shields.io/github/license/mashape/apistatus.svg)
 
 A Perl wrapper for VoiceIt's API 3.0 featuring Voice + Face Verification and Identification.
 

--- a/release.sh
+++ b/release.sh
@@ -73,7 +73,7 @@ then
   if [[ $wrapperplatformversion = $version ]];
   then
     uploadurl=$(curl -s -H "Authorization: token $GH_TOKEN" -H "Content-Type: application/json" --request POST --data '{"tag_name": "'$version'", "target_commitish": "master", "name": "'$version'", "body": "", "draft": false, "prerelease": false}' https://api.github.com/repos/voiceittech/VoiceIt3-Perl/releases | grep upload_url | awk '{print $2}' | cut -d '"' -f2 | cut -f1 -d '{')
-    curl -H "Authorization: token $GH_TOKEN" -H "Content-Type: text/plain" -X POST --data-binary '@./voiceIt2.pm' $uploadurl'?name=voiceIt2.pm' 1>&2
+    curl -H "Authorization: token $GH_TOKEN" -H "Content-Type: text/plain" -X POST --data-binary '@./voiceIt3.pm' $uploadurl'?name=voiceIt3.pm' 1>&2
 
     if [ "$?" != "0" ]
     then
@@ -104,7 +104,7 @@ then
         formattedmessages=$formattedmessages'|'$i
       done
 
-      curl -X POST -H "X-Admin-Password: $EMAILAUTHPASS" --data-urlencode "messages=$formattedmessages" -d "packageManaged=false" --data-urlencode "instructions=https://github.com/voiceittech/VoiceIt3-Perl/releases/download/$wrapperplatformversion/voiceIt2.pm" "https://api.voiceit.io/platform/38"
+      curl -X POST -H "X-Admin-Password: $EMAILAUTHPASS" --data-urlencode "messages=$formattedmessages" -d "packageManaged=false" --data-urlencode "instructions=https://github.com/voiceittech/VoiceIt3-Perl/releases/download/$wrapperplatformversion/voiceIt3.pm" "https://api.voiceit.io/platform/38"
     fi
 
     exit 0

--- a/test.pl
+++ b/test.pl
@@ -1,10 +1,10 @@
-require './voiceIt2.pm';
+require './voiceIt3.pm';
 use JSON::Parse 'parse_json';
 use LWP::Simple;
 print "**** Started Testing ****\n";
 my $self;
 
-my $myVoiceIt = voiceIt2->new($ENV{'VIAPIKEY'}, $ENV{'VIAPITOKEN'});
+my $myVoiceIt = voiceIt3->new($ENV{'VIAPIKEY'}, $ENV{'VIAPITOKEN'});
 
 # Test Webhook
 $myVoiceIt->addNotificationUrl('https://voiceit.io');

--- a/voiceIt3.pm
+++ b/voiceIt3.pm
@@ -1,4 +1,4 @@
-package voiceIt2;
+package voiceIt3;
 
 use strict;
 require LWP::UserAgent;


### PR DESCRIPTION
## Summary
- Rename all VoiceIt2 references to VoiceIt3 (package names, file names, README)
- Rename `voiceIt2.pm` → `voiceIt3.pm`
- Update package `voiceIt2` → `voiceIt3`
- Update `test.pl` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)